### PR TITLE
Support removal of multiple segments in create_partial_meshes.py

### DIFF
--- a/create_partial_meshes.py
+++ b/create_partial_meshes.py
@@ -145,21 +145,21 @@ def main():
                        help="Directory with segment PLYs (*_seg_XX.ply)")
     parser.add_argument("output_dir",
                        help="Output directory for partial meshes")
-    parser.add_argument("--total_segments", type=int, default=7,
-                       help="Total number of segments per mesh (default: 7).")
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--num_rand", type=int, default=0,
+    group.add_argument("--num_rand_segs", type=int, default=0,
                        help="Number of random segments to remove from each mesh (default: 0)")
-    group.add_argument("--segment_ids", type=str, default="6",
-                       help="Comma separated segment ids to remove (default: 6). If --num_rand is provided, --segments_ids is ignored.")
+    group.add_argument("--seg_ids", type=str, default="6",
+                       help="Comma separated segment ids to remove (default: 6). If --num_rand_segs is provided, --seg_ids is ignored.")
+    parser.add_argument("--total_segs", type=int, default=7,
+                       help="Total number of segments per mesh (default: 7)")
     args = parser.parse_args()
     create_validation_dataset(
         args.original_dir,
         args.segments_dir,
         args.output_dir,
-        num_rand_to_remove=args.num_rand,
-        segment_ids_to_remove=[int(id) for id in str.split(args.segment_ids, ",") if id],
-        total_num_segments=args.total_segments)
+        num_rand_to_remove=args.num_rand_segs,
+        segment_ids_to_remove=[int(id) for id in str.split(args.seg_ids, ",") if id],
+        total_num_segments=args.total_segs)
 
 if __name__ == "__main__":
     main()

--- a/create_partial_meshes.py
+++ b/create_partial_meshes.py
@@ -5,7 +5,7 @@ import os
 import vtk
 import json
 import argparse
-from glob import glob
+import random
 import pyvista as pv
 from scipy.spatial import cKDTree
 
@@ -39,7 +39,7 @@ def fast_subtract(original_pd, segment_pd, eps=0.02):
     # Keep faces far from segment
     orig['keep_face'] = (dists > eps).astype(int)
     result = orig.threshold(0.5, scalars='keep_face', invert=False)
-    return result.extract_surface().clean().triangulate()
+    return result.extract_surface(algorithm='dataset_surface').clean().triangulate()
 
 def flip_to_ras(polydata):
     # LPS to RAS coords (x flip)
@@ -66,52 +66,58 @@ def create_partial_mesh(original_ply, segment_ply, output_ply):
     print(f"  ✓ Saved: {output_ply}")
     return partial.GetNumberOfPoints()
 
-def create_validation_dataset(original_dir, segments_dir, output_dir, segment_to_remove=5):
+def create_validation_dataset(original_dir, segments_dir, output_dir, num_rand_to_remove=1, segment_ids_to_remove=[], total_num_segments=7):
     # Create output directory for partial meshes
     partial_dir = os.path.join(output_dir, "partial_meshes")
     os.makedirs(partial_dir, exist_ok=True)
-    # Find all segment files for the target segment
-    segment_pattern = os.path.join(segments_dir, f"*_seg_{segment_to_remove:02d}.ply")
-    segment_files = glob(segment_pattern)
-    if not segment_files:
-        raise RuntimeError(f"No segment files found matching: {segment_pattern}")
-    print(f"Found {len(segment_files)} meshes with segment {segment_to_remove}")
+    # Loop over input meshes
     results = []
-    for segment_file in segment_files:
-        # Extract base name
-        basename = os.path.basename(segment_file)
-        base_name = basename.replace(f"_seg_{segment_to_remove:02d}.ply", "")
+    for specimen_basename in os.listdir(original_dir):
         print(f"\n{'='*60}")
-        # Find corresponding original mesh (ground truth)
-        original_ply = os.path.join(original_dir, f"{base_name}.ply")
-        if not os.path.exists(original_ply):
-            vtk_path = os.path.join(original_dir, f"{base_name}.vtk")
-            if os.path.exists(vtk_path):
-                original_ply = vtk_path
-            else:
-                print(f"Original mesh not found: {base_name}.ply or .vtk")
-                continue
-
+        print(f"Processing: {specimen_basename}") 
+        # Determine segments to remove
+        specimen_name = os.path.splitext(specimen_basename)[0]
+        if num_rand_to_remove:
+            seg_ids = random.sample(list(range(total_num_segments)), k=num_rand_to_remove)
+        elif segment_ids_to_remove:
+            seg_ids = segment_ids_to_remove
+        else:
+            raise ValueError("num_rand_to_remove or segment_ids_to_remove must be valid.")
+        # Remove segments
         try:
-            # Create partial mesh
-            partial_path = os.path.join(partial_dir, f"{base_name}_partial.ply")
-            n_vertices = create_partial_mesh(original_ply, segment_file, partial_path) 
-            results.append({
-                'base_name': base_name,
-                'ground_truth': original_ply,  # Just reference the original
-                'partial': partial_path,
-                'removed_segment': segment_file,  # Just reference existing segment
-                'partial_vertices': int(n_vertices)
-            })
-            print(f"  ✓ Success!")
+            result = {
+                'base_name': specimen_name,
+                'ground_truth': specimen_basename,  # Just reference the original
+                'partial': os.path.join(partial_dir, f"{specimen_name}_partial.ply"),
+                'removed_segment_ids': [],  # IDs of segments which were removed from original
+                'removed_segments': [],  # Files of segments which were removed from original
+                'partial_vertices': None
+            }
+            # Create partial mesh by removing each segment recursively
+            in_path = os.path.join(original_dir, specimen_basename)
+            for seg_id in seg_ids:
+                # Check if segment exists for this specimen
+                segment_path = os.path.join(segments_dir, specimen_name + f"_seg_{seg_id:02d}.ply")
+                if not os.path.exists(segment_path):
+                    continue
+                # Remove segment
+                n_vertices = create_partial_mesh(in_path, segment_path, result['partial'])
+                print(f"  Removed segment: {seg_id}")
+                result['partial_vertices'] = n_vertices
+                result['removed_segment_ids'].append(seg_id)
+                result['removed_segments'].append(segment_path)
+                in_path = result['partial'] # Recursively remove segments
+            results.append(result)
+            print(f"  ✓ Success! Removed segments: {result['removed_segment_ids']}")
         except Exception as e:
             print(f"  ✗ Failed: {e}")
             import traceback
             traceback.print_exc()
             continue
+    
     # Save summary
     summary = {
-        'segment_removed': segment_to_remove,
+        'segments_removed': f"{num_rand_to_remove} random segments per mesh" if num_rand_to_remove else segment_ids_to_remove,
         'n_meshes': len(results),
         'original_dir': os.path.abspath(original_dir),
         'segments_dir': os.path.abspath(segments_dir),
@@ -139,14 +145,21 @@ def main():
                        help="Directory with segment PLYs (*_seg_XX.ply)")
     parser.add_argument("output_dir",
                        help="Output directory for partial meshes")
-    parser.add_argument("--segment", type=int, default=6,
-                       help="Segment number to remove (default: 6)")
+    parser.add_argument("--total_segments", type=int, default=7,
+                       help="Total number of segments per mesh (default: 7).")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--num_rand", type=int, default=0,
+                       help="Number of random segments to remove from each mesh (default: 0)")
+    group.add_argument("--segment_ids", type=str, default="6",
+                       help="Comma separated segment ids to remove (default: 6). If --num_rand is provided, --segments_ids is ignored.")
     args = parser.parse_args()
     create_validation_dataset(
         args.original_dir,
         args.segments_dir,
         args.output_dir,
-        segment_to_remove=args.segment)
+        num_rand_to_remove=args.num_rand,
+        segment_ids_to_remove=[int(id) for id in str.split(args.segment_ids, ",") if id],
+        total_num_segments=args.total_segments)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Modified `create_partial_meshes.py` to support removal of multiple segments. This is done by specifying a number of random segments to remove (e.g., `--num_rand=4`) or a list of segments to remove (e.g,. `--segment_ids=0,3,4`). The total number of segments can be specified if different than our current default of 7 (e.g., `--total_segments=10`).
- The generated results file `partial_meshing_summary.json` will now also contain a list of IDs and paths of all segments removed for each mesh.
- Instead of finding all segments upfront and looping over them, the script now loops over each input mesh and finds the appropriate segment files.

Updated help message for reference:

```
usage: create_partial_meshes.py [-h] (--num_rand_segs NUM_RAND_SEGS | --seg_ids SEG_IDS) [--total_segs TOTAL_SEGS] original_dir segments_dir output_dir

Create partial meshes for shape completion validation

positional arguments:
  original_dir          Directory with original meshes (ground truth)
  segments_dir          Directory with segment PLYs (*_seg_XX.ply)
  output_dir            Output directory for partial meshes

options:
  -h, --help            show this help message and exit
  --num_rand_segs NUM_RAND_SEGS
                        Number of random segments to remove from each mesh (default: 0)
  --seg_ids SEG_IDS     Comma separated segment ids to remove (default: 6). If --num_rand_segs is provided, --seg_ids is ignored.
  --total_segs TOTAL_SEGS
                        Total number of segments per mesh (default: 7)
```