### PR TITLE
Fix opt lr sched for lat and model; add lr test

### DIFF
--- a/NSM/configs/default_config.json
+++ b/NSM/configs/default_config.json
@@ -83,13 +83,13 @@
     "LearningRateSchedule": [
         {
             "Type": "Step",
-            "Initial": 0.0005,
+            "Initial": 0.001,
             "Interval": 500,
             "Factor": 0.5
         },
         {
             "Type": "Step",
-            "Initial": 0.001,
+            "Initial": 0.0005,
             "Interval": 500,
             "Factor": 0.5
         }

--- a/NSM/configs/generate_sdf_default_config.py
+++ b/NSM/configs/generate_sdf_default_config.py
@@ -65,8 +65,8 @@ config = {
     "weight_decay": 0.0001,
     # Learning Rate:
     "LearningRateSchedule": [
-        {"Type": "Step", "Initial": 0.0005, "Interval": 500, "Factor": 0.5},
-        {"Type": "Step", "Initial": 0.001, "Interval": 500, "Factor": 0.5},
+        {"Type": "Step", "Initial": 0.001, "Interval": 500, "Factor": 0.5}, # index 0 = model/decoder LR 
+        {"Type": "Step", "Initial": 0.0005, "Interval": 500, "Factor": 0.5}, # index 1 = latent-code LR
     ],
     # regularize learning:
     "grad_clip": None,

--- a/NSM/train/train_deep_sdf.py
+++ b/NSM/train/train_deep_sdf.py
@@ -8,6 +8,7 @@ from NSM.utils import (
     get_latent_vecs,
     get_checkpoints,
     clear_gpu_cache,
+    rename_optimizer_param_groups,
 )
 from NSM.losses import eikonal_loss
 from NSM.reconstruct import (
@@ -64,9 +65,6 @@ def train_deep_sdf(config, model, sdf_dataset, use_wandb=False):
     config["checkpoints"] = get_checkpoints(config)
     config["lr_schedules"] = get_learning_rate_schedules(config)
 
-    if "resume_epoch" not in config:
-        config["resume_epoch"] = 0
-
     model = model.to(config["device"])
     # Log training results across epochs
     if use_wandb is True:
@@ -108,32 +106,44 @@ def train_deep_sdf(config, model, sdf_dataset, use_wandb=False):
 
     if config["resume_epoch"] > 1:
         print("Loading model, optimizer, and latent states from epoch", config["resume_epoch"])
-        # load the model states
-        model.load_state_dict(
-            torch.load(
-                os.path.join(
-                    config["experiment_directory"], "model", f'{config["resume_epoch"]}.pth'
-                )
-            )["model"]
+
+        model_ckpt_path = os.path.join(
+            config["experiment_directory"], "model", f'{config["resume_epoch"]}.pth'
+        )
+        latent_ckpt_path = os.path.join(
+            config["experiment_directory"], "latent_codes", f'{config["resume_epoch"]}.pth'
         )
 
-        # load the optimizer states
-        optimizer.load_state_dict(
-            torch.load(
-                os.path.join(
-                    config["experiment_directory"], "model", f'{config["resume_epoch"]}.pth'
-                )
-            )["optimizer"]
-        )
+        model_checkpoint = torch.load(model_ckpt_path, map_location=config["device"])
+        latent_checkpoint = torch.load(latent_ckpt_path, map_location=config["device"])
 
-        # load the latent vectors
-        latent_vecs.load_state_dict(
-            torch.load(
-                os.path.join(
-                    config["experiment_directory"], "latent_codes", f'{config["resume_epoch"]}.pth'
+        model.load_state_dict(model_checkpoint["model"])
+
+        optimizer_state = model_checkpoint.get("optimizer")
+        if optimizer_state is None:
+            raise ValueError(f"No optimizer state found in checkpoint: {model_ckpt_path}")
+        optimizer.load_state_dict(optimizer_state)
+
+        group_names = model_checkpoint.get("optimizer_group_names")
+        if group_names is not None:
+            if len(group_names) != len(optimizer.param_groups):
+                raise ValueError(
+                    f"optimizer_group_names length mismatch: "
+                    f"{len(group_names)} names for {len(optimizer.param_groups)} param groups"
                 )
-            )["latent_codes"]
-        )
+            for group, name in zip(optimizer.param_groups, group_names):
+                if name is None:
+                    raise ValueError("Checkpoint contains optimizer param group with missing name")
+                group["name"] = name
+        else:
+            n_model_groups = len(model) if isinstance(model, (list, tuple)) else 1
+            rename_optimizer_param_groups(
+                optimizer,
+                n_model_groups=n_model_groups,
+                has_classification_heads=False,
+            )
+
+        latent_vecs.load_state_dict(latent_checkpoint["latent_codes"])
 
     # profiler that runs if config['profiler'] is True, else a dummy profiler is used and should have no effect
     with get_profiler(config) as profiler:

--- a/NSM/train/train_deep_sdf_contrastive.py
+++ b/NSM/train/train_deep_sdf_contrastive.py
@@ -8,6 +8,7 @@ from NSM.utils import (
     get_latent_vecs,
     get_checkpoints,
     clear_gpu_cache,
+    rename_optimizer_param_groups,
 )
 from NSM.losses import eikonal_loss
 from NSM.reconstruct import (
@@ -228,9 +229,6 @@ def train_deep_sdf(config, model, sdf_dataset, use_wandb=False):
     config["checkpoints"] = get_checkpoints(config)
     config["lr_schedules"] = get_learning_rate_schedules(config)
 
-    if "resume_epoch" not in config:
-        config["resume_epoch"] = 0
-
     model = model.to(config["device"])
     # Log training results across epochs
     # Always write per-epoch losses CSV to fixed path regardless of wandb usage
@@ -285,38 +283,49 @@ def train_deep_sdf(config, model, sdf_dataset, use_wandb=False):
 
     if config["resume_epoch"] > 1:
         print("Loading model, optimizer, and latent states from epoch", config["resume_epoch"])
-        # load the model states
-        model.load_state_dict(
-            torch.load(
-                os.path.join(
-                    config["experiment_directory"], "model", f'{config["resume_epoch"]}.pth'
-                )
-            )["model"]
+
+        model_ckpt_path = os.path.join(
+            config["experiment_directory"], "model", f'{config["resume_epoch"]}.pth'
+        )
+        latent_ckpt_path = os.path.join(
+            config["experiment_directory"], "latent_codes", f'{config["resume_epoch"]}.pth'
         )
 
-        # load the optimizer states
-        optimizer.load_state_dict(
-            torch.load(
-                os.path.join(
-                    config["experiment_directory"], "model", f'{config["resume_epoch"]}.pth'
-                )
-            )["optimizer"]
-        )
+        model_checkpoint = torch.load(model_ckpt_path, map_location=config["device"])
+        latent_checkpoint = torch.load(latent_ckpt_path, map_location=config["device"])
 
-        # load the latent vectors
-        latent_vecs.load_state_dict(
-            torch.load(
-                os.path.join(
-                    config["experiment_directory"], "latent_codes", f'{config["resume_epoch"]}.pth'
-                )
-            )["latent_codes"]
-        )
+        model.load_state_dict(model_checkpoint["model"])
 
-        # Recompute average latents from loaded checkpoint so epoch N+1 starts warm, new avg latent used for next epoch's contrastive loss
+        optimizer_state = model_checkpoint.get("optimizer")
+        if optimizer_state is None:
+            raise ValueError(f"No optimizer state found in checkpoint: {model_ckpt_path}")
+        optimizer.load_state_dict(optimizer_state)
+
+        group_names = model_checkpoint.get("optimizer_group_names")
+        if group_names is not None:
+            if len(group_names) != len(optimizer.param_groups):
+                raise ValueError(
+                    f"optimizer_group_names length mismatch: "
+                    f"{len(group_names)} names for {len(optimizer.param_groups)} param groups"
+                )
+            for group, name in zip(optimizer.param_groups, group_names):
+                if name is None:
+                    raise ValueError("Checkpoint contains optimizer param group with missing name")
+                group["name"] = name
+        else:
+            n_model_groups = len(model) if isinstance(model, (list, tuple)) else 1
+            rename_optimizer_param_groups(
+                optimizer,
+                n_model_groups=n_model_groups,
+                has_classification_heads=False,
+            )
+
+        latent_vecs.load_state_dict(latent_checkpoint["latent_codes"])
+
         avg_latent_species, avg_latent_genus = _compute_avg_latents(
             latent_vecs,
-            taxonomic_mappings['species_to_indices'],
-            taxonomic_mappings['genus_to_indices'],
+            taxonomic_mappings["species_to_indices"],
+            taxonomic_mappings["genus_to_indices"],
             latent_size=config["latent_size"],
         )
         print(f"[Taxonomic] Recomputed avg latents from resume epoch {config['resume_epoch']}")

--- a/NSM/train/train_deep_sdf_hierarchy.py
+++ b/NSM/train/train_deep_sdf_hierarchy.py
@@ -8,6 +8,7 @@ from NSM.utils import (
     get_latent_vecs,
     get_checkpoints,
     clear_gpu_cache,
+    rename_optimizer_param_groups,
 )
 from NSM.losses import eikonal_loss
 from NSM.reconstruct import (
@@ -176,29 +177,52 @@ def train_deep_sdf(config, model, sdf_dataset, use_wandb=False):
     if classification_heads is not None:
         optimizer.add_param_group(
             {
+                "name": "classification_heads",
                 "params": classification_heads.parameters(),
                 "lr": config["lr_schedules"][0].get_learning_rate(0),
             }
         )
-        config["lr_schedules"].append(config["lr_schedules"][0])
 
     if config["resume_epoch"] > 1:
         print("Loading model, optimizer, and latent states from epoch", config["resume_epoch"])
-        model.load_state_dict(
-            torch.load(
-                os.path.join(config["experiment_directory"], "model", f'{config["resume_epoch"]}.pth')
-            )["model"]
+
+        model_ckpt_path = os.path.join(
+            config["experiment_directory"], "model", f'{config["resume_epoch"]}.pth'
         )
-        optimizer.load_state_dict(
-            torch.load(
-                os.path.join(config["experiment_directory"], "model", f'{config["resume_epoch"]}.pth')
-            )["optimizer"]
+        latent_ckpt_path = os.path.join(
+            config["experiment_directory"], "latent_codes", f'{config["resume_epoch"]}.pth'
         )
-        latent_vecs.load_state_dict(
-            torch.load(
-                os.path.join(config["experiment_directory"], "latent_codes", f'{config["resume_epoch"]}.pth')
-            )["latent_codes"]
-        )
+
+        model_checkpoint = torch.load(model_ckpt_path, map_location=config["device"])
+        latent_checkpoint = torch.load(latent_ckpt_path, map_location=config["device"])
+
+        model.load_state_dict(model_checkpoint["model"])
+
+        optimizer_state = model_checkpoint.get("optimizer")
+        if optimizer_state is None:
+            raise ValueError(f"No optimizer state found in checkpoint: {model_ckpt_path}")
+        optimizer.load_state_dict(optimizer_state)
+
+        group_names = model_checkpoint.get("optimizer_group_names")
+        if group_names is not None:
+            if len(group_names) != len(optimizer.param_groups):
+                raise ValueError(
+                    f"optimizer_group_names length mismatch: "
+                    f"{len(group_names)} names for {len(optimizer.param_groups)} param groups"
+                )
+            for group, name in zip(optimizer.param_groups, group_names):
+                if name is None:
+                    raise ValueError("Checkpoint contains optimizer param group with missing name")
+                group["name"] = name
+        else:
+            n_model_groups = len(model) if isinstance(model, (list, tuple)) else 1
+            rename_optimizer_param_groups(
+                optimizer,
+                n_model_groups=n_model_groups,
+                has_classification_heads=classification_heads is not None,
+            )
+
+        latent_vecs.load_state_dict(latent_checkpoint["latent_codes"])
 
         heads_path = os.path.join(
             config["experiment_directory"], "classification_heads", f'{config["resume_epoch"]}.pth'

--- a/NSM/train/train_deep_sdf_multi_head.py
+++ b/NSM/train/train_deep_sdf_multi_head.py
@@ -16,11 +16,18 @@ import os
 import torch
 import time
 import numpy as np
+import warnings
 
 loss_l1 = torch.nn.L1Loss(reduction="none")
 
 
 def train_deep_sdf(config, models: tuple, sdf_dataset, use_wandb=False):
+    
+    warnings.warn(
+        "train_deep_sdf_multi_head is deprecated and known-broken (only the last model's "
+        "parameters reach the optimizer; no optimizer state saving/resume). "
+        "Use train_deep_sdf with objects_per_decoder > 1 instead.",
+        DeprecationWarning, stacklevel=2,)
 
     config = add_plain_lr_to_config(config)
 

--- a/NSM/utils.py
+++ b/NSM/utils.py
@@ -102,11 +102,34 @@ def get_learning_rate_schedules(config):
 
 
 def adjust_learning_rate(lr_schedules, optimizer, epoch, verbose=False):
-    if verbose is True:
-        print("optimizer param groups: ", optimizer.param_groups)
-        print("lr_schedules: ", lr_schedules)
-    for i, param_group in enumerate(optimizer.param_groups):
-        param_group["lr"] = lr_schedules[i].get_learning_rate(epoch)
+    """
+    Prior to this fix (all Adam/AdamW runs from May 2023 → Jul 2026), the two
+    `LearningRateSchedule` entries were applied swapped at runtime: latents trained under
+    entry 0, the model under entry 1. To reproduce a historical Adam/AdamW run with fixed
+    code, swap the two entries in that run's config. Runs using `schedule_free_*` optimizers
+    already used the intended mapping — do **not** swap those configs.   
+    """
+    if len(lr_schedules) < 2:
+        raise ValueError(
+            f"Expected at least 2 lr_schedules (index 0 = model, index 1 = latent codes); "
+            f"got {len(lr_schedules)}"
+        )
+    for param_group in optimizer.param_groups:
+        name = param_group.get("name")
+        if name == "latent":
+            param_group["lr"] = lr_schedules[1].get_learning_rate(epoch)
+        elif name == "classification_heads" or (name is not None and name.startswith("model_")):
+            param_group["lr"] = lr_schedules[0].get_learning_rate(epoch)
+        else:
+            raise KeyError(
+                "optimizer param_group missing a recognized 'name' "
+                "('latent' or 'model_*'). If the optimizer state was loaded from a "
+                "checkpoint, names must be re-injected after load_state_dict "
+                "(torch drops custom group keys) — see rename_optimizer_param_groups()."
+            )
+        
+        if verbose:
+            print(f"{name}: {param_group['lr']}")
 
 
 def save_latent_vectors(config, epoch, latent_vec, latent_codes_subdir="latent_codes"):
@@ -124,31 +147,38 @@ def save_latent_vectors(config, epoch, latent_vec, latent_codes_subdir="latent_c
 
 
 def save_model(config, epoch, decoder, model_subdir="model", optimizer=None):
-    if type(decoder) not in (list, tuple):
+    """
+    Save decoder checkpoint.
+
+    Stores optimizer state and explicit optimizer param-group names so semantic
+    group identity can be restored after optimizer.load_state_dict().
+    """
+    if not isinstance(decoder, (list, tuple)):
         decoder = [decoder]
 
     filename = f"{epoch}.pth"
 
+    optimizer_state = None
+    optimizer_group_names = None
+    if optimizer is not None:
+        optimizer_group_names = [group.get("name") for group in optimizer.param_groups]
+        if any(name is None for name in optimizer_group_names):
+            raise ValueError("All optimizer param groups must have a 'name' before saving.")
+        optimizer_state = optimizer.state_dict()
+
     for decoder_idx, decoder_ in enumerate(decoder):
-        if len(decoder) > 1:
-            model_subdir_ = model_subdir + f"_{decoder_idx}"
-        else:
-            model_subdir_ = model_subdir
-
+        model_subdir_ = model_subdir + f"_{decoder_idx}" if len(decoder) > 1 else model_subdir
         folder_save = os.path.join(config["experiment_directory"], model_subdir_)
-        if not os.path.exists(folder_save):
-            os.makedirs(folder_save, exist_ok=True)
+        os.makedirs(folder_save, exist_ok=True)
 
-        dict_ = {
+        checkpoint = {
             "epoch": epoch,
             "model": decoder_.state_dict(),
-            "optimizer": optimizer.state_dict() if optimizer is not None else "None",
+            "optimizer": optimizer_state,
+            "optimizer_group_names": optimizer_group_names,
         }
 
-        torch.save(
-            dict_,
-            os.path.join(folder_save, filename),
-        )
+        torch.save(checkpoint, os.path.join(folder_save, filename))
 
 
 def save_model_params(config, list_mesh_paths):
@@ -209,18 +239,39 @@ def get_latent_vecs(num_objects, config):
 
 
 def get_optimizer(model, latent_vecs, lr_schedules, optimizer="Adam", weight_decay=0.0001):
+    """
+    Construct the optimizer with named parameter groups.
+
+    The repository convention is:
+
+    - ``lr_schedules[0]`` → model/decoder parameters
+    - ``lr_schedules[1]`` → latent code parameters
+
+    Parameter groups are kept in the order ``[latent, model...]`` for checkpoint
+    compatibility, but are named (``"latent"``, ``"model_0"``, ...) so
+    :func:`adjust_learning_rate` maps schedules by name rather than by position.
+
+    .. note::
+    Prior to this fix (all Adam/AdamW runs from May 2023 → Jul 2026), the two
+    `LearningRateSchedule` entries were applied swapped at runtime: latents trained under
+    entry 0, the model under entry 1. To reproduce a historical Adam/AdamW run with fixed
+    code, swap the two entries in that run's config. Runs using `schedule_free_*` optimizers
+    already used the intended mapping — do **not** swap those configs.   
+    """
     if type(model) not in (list, tuple):
         model = [model]
 
     list_params = [
         {
+            "name": "latent",
             "params": latent_vecs.parameters(),
             "lr": lr_schedules[1].get_learning_rate(0),
         }
     ]
-    for model_ in model:
+    for idx, model_ in enumerate(model):
         list_params.append(
             {
+                "name": f"model_{idx}",
                 "params": model_.parameters(),
                 "lr": lr_schedules[0].get_learning_rate(0),
             }
@@ -240,6 +291,30 @@ def get_optimizer(model, latent_vecs, lr_schedules, optimizer="Adam", weight_dec
         raise ValueError(f"Unknown optimizer: {optimizer}")
 
     return optimizer
+
+def rename_optimizer_param_groups(optimizer, n_model_groups, has_classification_heads=False):
+    """
+    Re-apply semantic names after optimizer.load_state_dict().
+    Assumes get_optimizer() group order [latent, model_0, model_1, ...]
+    and, when present, a final classification_heads group added afterward.
+    Fallback for checkpoints saved before Jul 2026 when optimizer lr scheduling fix implemented. 
+    """
+    expected_groups = 1 + n_model_groups + int(has_classification_heads)
+    if len(optimizer.param_groups) != expected_groups:
+        raise ValueError(
+            f"Expected {expected_groups} optimizer param groups "
+            f"(1 latent, {n_model_groups} model, "
+            f"{int(has_classification_heads)} classification_heads), "
+            f"got {len(optimizer.param_groups)}"
+        )
+
+    optimizer.param_groups[0]["name"] = "latent"
+
+    for idx in range(n_model_groups):
+        optimizer.param_groups[1 + idx]["name"] = f"model_{idx}"
+
+    if has_classification_heads:
+        optimizer.param_groups[-1]["name"] = "classification_heads"
 
 
 def symmetric_chammfer(p1, p2, n_pts):

--- a/test_lr_schedules.py
+++ b/test_lr_schedules.py
@@ -1,0 +1,239 @@
+import unittest
+import torch
+
+from NSM.utils import (
+    StepLearningRateSchedule,
+    get_optimizer,
+    adjust_learning_rate,
+    rename_optimizer_param_groups,
+)
+
+
+def _build_schedules(model_initial=0.005, latent_initial=1e-4, interval=10, factor=0.5):
+    return [
+        StepLearningRateSchedule(
+            initial=model_initial,
+            interval=interval,
+            factor=factor,
+        ),
+        StepLearningRateSchedule(
+            initial=latent_initial,
+            interval=interval,
+            factor=factor,
+        ),
+    ]
+
+
+def _group_by_param_identity(optimizer, model, latent_vecs, classification_heads=None):
+    model_param_ids = {id(p) for p in model.parameters()}
+    latent_param_ids = {id(p) for p in latent_vecs.parameters()}
+    cls_param_ids = (
+        {id(p) for p in classification_heads.parameters()}
+        if classification_heads is not None
+        else set()
+    )
+
+    found = {}
+    for group in optimizer.param_groups:
+        group_param_ids = {id(p) for p in group["params"]}
+
+        if group_param_ids & latent_param_ids:
+            found["latent"] = group
+        elif group_param_ids & model_param_ids:
+            found.setdefault("model", []).append(group)
+        elif cls_param_ids and group_param_ids & cls_param_ids:
+            found["classification_heads"] = group
+
+    return found
+
+
+class TestLRSchedules(unittest.TestCase):
+    def assertAlmostEqualRelative(self, a, b, places=12):
+        self.assertAlmostEqual(a, b, places=places)
+
+    def test_adjust_lr_maps_schedules_to_correct_groups(self):
+        model = torch.nn.Linear(8, 1)
+        latent_vecs = torch.nn.Embedding(4, 8)
+        schedules = _build_schedules(model_initial=0.005, latent_initial=1e-4)
+
+        optimizer = get_optimizer(
+            model,
+            latent_vecs,
+            lr_schedules=schedules,
+            optimizer="AdamW",
+            weight_decay=0.0,
+        )
+
+        adjust_learning_rate(schedules, optimizer, epoch=1)
+        groups = _group_by_param_identity(optimizer, model, latent_vecs)
+
+        self.assertAlmostEqualRelative(
+            groups["model"][0]["lr"],
+            schedules[0].get_learning_rate(1),
+        )
+        self.assertAlmostEqualRelative(
+            groups["latent"]["lr"],
+            schedules[1].get_learning_rate(1),
+        )
+
+    def test_lr_decay_follows_correct_schedule_per_group(self):
+        model = torch.nn.Linear(8, 1)
+        latent_vecs = torch.nn.Embedding(4, 8)
+        schedules = _build_schedules(
+            model_initial=0.005,
+            latent_initial=1e-4,
+            interval=10,
+            factor=0.5,
+        )
+
+        optimizer = get_optimizer(
+            model,
+            latent_vecs,
+            lr_schedules=schedules,
+            optimizer="AdamW",
+            weight_decay=0.0,
+        )
+
+        for epoch in [1, 10, 11, 20, 25]:
+            adjust_learning_rate(schedules, optimizer, epoch=epoch)
+            groups = _group_by_param_identity(optimizer, model, latent_vecs)
+
+            self.assertAlmostEqualRelative(
+                groups["model"][0]["lr"],
+                schedules[0].get_learning_rate(epoch),
+            )
+            self.assertAlmostEqualRelative(
+                groups["latent"]["lr"],
+                schedules[1].get_learning_rate(epoch),
+            )
+
+    def test_resume_round_trip_preserves_mapping(self):
+        model = torch.nn.Linear(8, 1)
+        latent_vecs = torch.nn.Embedding(4, 8)
+        schedules = _build_schedules(model_initial=0.005, latent_initial=1e-4)
+
+        optimizer = get_optimizer(
+            model,
+            latent_vecs,
+            lr_schedules=schedules,
+            optimizer="AdamW",
+            weight_decay=0.0,
+        )
+
+        saved_state = optimizer.state_dict()
+
+        fresh_model = torch.nn.Linear(8, 1)
+        fresh_latent_vecs = torch.nn.Embedding(4, 8)
+        fresh_optimizer = get_optimizer(
+            fresh_model,
+            fresh_latent_vecs,
+            lr_schedules=schedules,
+            optimizer="AdamW",
+            weight_decay=0.0,
+        )
+
+        fresh_optimizer.load_state_dict(saved_state)
+        rename_optimizer_param_groups(
+            fresh_optimizer,
+            n_model_groups=1,
+            has_classification_heads=False,
+        )
+        adjust_learning_rate(schedules, fresh_optimizer, epoch=1)
+
+        groups = _group_by_param_identity(fresh_optimizer, fresh_model, fresh_latent_vecs)
+
+        self.assertAlmostEqualRelative(
+            groups["model"][0]["lr"],
+            schedules[0].get_learning_rate(1),
+        )
+        self.assertAlmostEqualRelative(
+            groups["latent"]["lr"],
+            schedules[1].get_learning_rate(1),
+        )
+
+    def test_adjust_lr_raises_without_group_names(self):
+        model = torch.nn.Linear(8, 1)
+        latent_vecs = torch.nn.Embedding(4, 8)
+        schedules = _build_schedules()
+
+        optimizer = get_optimizer(
+            model,
+            latent_vecs,
+            lr_schedules=schedules,
+            optimizer="AdamW",
+            weight_decay=0.0,
+        )
+
+        for group in optimizer.param_groups:
+            group.pop("name", None)
+
+        with self.assertRaisesRegex(KeyError, "missing a recognized 'name'"):
+            adjust_learning_rate(schedules, optimizer, epoch=1)
+
+    def test_multi_model_list_all_models_get_schedule0(self):
+        model_a = torch.nn.Linear(8, 4)
+        model_b = torch.nn.Linear(8, 1)
+        latent_vecs = torch.nn.Embedding(4, 8)
+        schedules = _build_schedules(model_initial=0.005, latent_initial=1e-4)
+
+        optimizer = get_optimizer(
+            [model_a, model_b],
+            latent_vecs,
+            lr_schedules=schedules,
+            optimizer="AdamW",
+            weight_decay=0.0,
+        )
+
+        adjust_learning_rate(schedules, optimizer, epoch=1)
+
+        model_a_ids = {id(p) for p in model_a.parameters()}
+        model_b_ids = {id(p) for p in model_b.parameters()}
+        latent_ids = {id(p) for p in latent_vecs.parameters()}
+
+        found_model_lrs = []
+        latent_lr = None
+
+        for group in optimizer.param_groups:
+            param_ids = {id(p) for p in group["params"]}
+            if param_ids & latent_ids:
+                latent_lr = group["lr"]
+            elif param_ids & model_a_ids:
+                found_model_lrs.append(group["lr"])
+            elif param_ids & model_b_ids:
+                found_model_lrs.append(group["lr"])
+
+        self.assertEqual(len(found_model_lrs), 2)
+        expected_model_lr = schedules[0].get_learning_rate(1)
+        for lr in found_model_lrs:
+            self.assertAlmostEqualRelative(lr, expected_model_lr)
+
+        self.assertAlmostEqualRelative(
+            latent_lr,
+            schedules[1].get_learning_rate(1),
+        )
+
+    def test_too_few_schedules_raises(self):
+        model = torch.nn.Linear(8, 1)
+        latent_vecs = torch.nn.Embedding(4, 8)
+        schedules = [
+            StepLearningRateSchedule(
+                initial=0.005,
+                interval=10,
+                factor=0.5,
+            )
+        ]
+
+        optimizer = get_optimizer(
+            model,
+            latent_vecs,
+            lr_schedules=_build_schedules(),
+            optimizer="AdamW",
+            weight_decay=0.0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Expected at least 2 lr_schedules"):
+            adjust_learning_rate(schedules, optimizer, epoch=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vertebrae_config.json
+++ b/vertebrae_config.json
@@ -75,15 +75,15 @@
     "LearningRateSchedule": [
         {
             "Type": "Step",
-            "Initial": 0.005,
-            "Interval": 16.666666666666668,
-            "Factor": 0.9523809523809523
-        },
-        {
-            "Type": "Step",
             "Initial": 0.0001,
             "Interval": 1000,
             "Factor": 0.1
+        },
+        {
+            "Type": "Step",
+            "Initial": 0.005,
+            "Interval": 16.666666666666668,
+            "Factor": 0.9523809523809523
         }
     ],
     "grad_clip": null,


### PR DESCRIPTION
## Summary

This PR fixes a long-standing LR schedule mapping bug in Adam/AdamW training.

Between May 2023 and Jul 2026, `LearningRateSchedule[0]` and `LearningRateSchedule[1]` were effectively applied to the wrong optimizer groups at runtime: latents followed entry 0, while model/decoder parameters followed entry 1. This PR restores the intended mapping:

- `LearningRateSchedule[0]` -> model/decoder
- `LearningRateSchedule[1]` -> latent codes

`schedule_free_*` optimizers were not affected.

From vertebrae_config.json:
 ```
        "LearningRateSchedule": [
        {
            "Type": "Step",
            "Initial": 0.0001,
            "Interval": 1000,
            "Factor": 0.1
        },
        {
            "Type": "Step",
            "Initial": 0.005,
            "Interval": 16.666666666666668,
            "Factor": 0.9523809523809523
        }
 ```


## Impact

To reproduce a historical Adam/AdamW run with the fixed code, swap the two `LearningRateSchedule` entries in that run's config.

Do **not** swap configs for `schedule_free_*` runs.

## Root cause

`get_optimizer()` assigned the correct initial LRs, but `adjust_learning_rate()` updated optimizer param groups positionally using an outdated group-order assumption. Since this ran every epoch, the full schedules were swapped for Adam/AdamW runs.

## Fix

- add named optimizer param groups in `NSM/utils.py`
- map LR schedules by group name instead of param-group position
- preserve/restore optimizer group names across resume
- update default configs to match the intended convention
- add regression coverage for LR assignment, decay, resume, and failure cases

## Files changed

- `NSM/utils.py`
- `NSM/train/train_deep_sdf.py`
- `NSM/train/train_deep_sdf_contrastive.py`
- `NSM/train/train_deep_sdf_hierarchy.py`
- `NSM/train/train_deep_sdf_multi_head.py`
- `NSM/configs/default_config.json`
- `NSM/configs/generate_sdf_default_config.py`
- `vertebrae_config.json`
- `test_lr_schedules.py`

## Testing

Added a new root-level `unittest` test file nsm/test_lr_schedules.py.

## Detailed changes

- `NSM/utils.py`: updated `get_optimizer()` to create named optimizer param groups (`latent`, `model_*`), fixed `adjust_learning_rate()` to map schedules by name instead of position, added `rename_optimizer_param_groups(...)` for old checkpoints, and updated `save_model()` to save `optimizer_group_names` with the optimizer state.
- `NSM/train/train_deep_sdf.py`: updated resume logic to load checkpoints once, restore optimizer group names from checkpoint metadata when present, and fall back to `rename_optimizer_param_groups(...)` for older checkpoints.
- `NSM/train/train_deep_sdf_contrastive.py`: made the same resume/load fix as `train_deep_sdf.py` so optimizer LR mapping is consistent on resume.
- `NSM/train/train_deep_sdf_hierarchy.py`: made the same resume/load fix, named the added classification-head optimizer group `classification_heads`, and removed the old extra-schedule append workaround.
- `NSM/train/train_deep_sdf_multi_head.py`: added a deprecation warning noting the file is known-broken and recommending `train_deep_sdf` with `objects_per_decoder > 1`.
- `NSM/configs/default_config.json`: swapped the two `LearningRateSchedule` entries so fixed code preserves the effective behavior of historical Adam/AdamW runs.
- `NSM/configs/generate_sdf_default_config.py`: swapped the default schedule entry order and added/updated the note that index 0 is model and index 1 is latent.
- `NSM/configs/deep_sdf_config`: annotated the intended schedule index meanings for clarity.
- `test_lr_schedules.py`: added regression tests covering named-group LR assignment, decay behavior, resume behavior, missing-name failure, multi-model behavior, and too-few-schedules failure.