### PR TITLE
Implement and evaluate fast mode (encoder) for shape completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ literature/
 .DS_Store
 reports/
 /hierarchy/grid_search_results/
+# Encoder: regenerable data/logs/eval artifacts + model binaries (shipped separately)
+encoder/data/
+encoder/checkpoints/

--- a/FossilNsmModule/ShapeCompletion.py
+++ b/FossilNsmModule/ShapeCompletion.py
@@ -33,6 +33,23 @@ class ShapeCompletionWidget(FossilNsmCommonWidget, ScriptedLoadableModuleWidget)
 
         self.addFossilNsmInputSection(self.layout)
 
+        # Fast Mode Collapsible Layout (one-shot encoder instead of optimization)
+        fastCollapsible = ctk.ctkCollapsibleButton()
+        fastCollapsible.text = "Fast Mode (Encoder)"
+        fastCollapsible.collapsed = True
+        self.layout.addWidget(fastCollapsible)
+        fastLayout = qt.QFormLayout(fastCollapsible)
+
+        self.fastModeCheckbox = qt.QCheckBox("Use encoder (skip latent optimization)")
+        self.fastModeCheckbox.setChecked(False)
+        fastLayout.addRow("", self.fastModeCheckbox)
+
+        self.encoderCkptInput = qt.QLineEdit("encoder/checkpoints/encoder.pt")
+        fastLayout.addRow("Encoder Checkpoint:", self.encoderCkptInput)
+
+        self.refineItersInput = qt.QLineEdit("0")
+        fastLayout.addRow("Refine Iterations:", self.refineItersInput)
+
         # Optimization Settings Collapsible Layout
         optimCollapsible = ctk.ctkCollapsibleButton()
         optimCollapsible.text = "Optimization Settings"
@@ -113,6 +130,9 @@ class ShapeCompletionWidget(FossilNsmCommonWidget, ScriptedLoadableModuleWidget)
         self.estimateUncertaintyCheckbox.connect("stateChanged(int)", self.onToggleUncertaintyOptions)
         self.propagationModeCombobox.connect("currentIndexChanged(int)", self.onToggleUncertaintyOptions)
         self.onToggleUncertaintyOptions()
+
+        self.fastModeCheckbox.connect("stateChanged(int)", self.onToggleFastMode)
+        self.onToggleFastMode()
 
         # Run Button
         self.runButton = qt.QPushButton("Run Inference")
@@ -197,6 +217,16 @@ class ShapeCompletionWidget(FossilNsmCommonWidget, ScriptedLoadableModuleWidget)
         is_mc = self.propagationModeCombobox.currentText == "montecarlo"
         self.nSamplesInput.setEnabled(enabled and is_mc)
 
+    # Toggle Fast Mode Inputs
+    def onToggleFastMode(self, state=None):
+        fast = self.fastModeCheckbox.isChecked()
+        self.encoderCkptInput.setEnabled(fast)
+        self.refineItersInput.setEnabled(fast)
+        # In fast mode the encoder replaces the optimization phases; grey them out.
+        for w in (self.phase1ItersInput, self.phase1LrInput, self.phase1LambdaInput,
+                  self.phase2ItersInput, self.phase2LrInput, self.phase2LambdaInput):
+            w.setEnabled(not fast)
+
     def updateRunButton(self):
         self.runButton.setEnabled(self.commonInputsReady())
 
@@ -239,6 +269,11 @@ class ShapeCompletionWidget(FossilNsmCommonWidget, ScriptedLoadableModuleWidget)
             "--phase2_lambda_reg", self.phase2LambdaInput.text,
             "--n_pts_per_axis", self.nPtsPerAxisInput.text,
         ]
+        if self.fastModeCheckbox.isChecked():
+            cmd.append("--fast_mode")
+            cmd.extend(["--refine_iters", self.refineItersInput.text])
+            if self.encoderCkptInput.text.strip():
+                cmd.extend(["--encoder_ckpt", self.encoderCkptInput.text.strip()])
         if self.estimateUncertaintyCheckbox.isChecked():
             cmd.append("--estimate_uncertainty")
             cmd.extend(["--propagation_mode", self.propagationModeCombobox.currentText])

--- a/README.md
+++ b/README.md
@@ -51,6 +51,46 @@ cd NSM/nsm
 python train_model.py
 ```
 
+## Fast Shape Completion (Encoder)
+
+The Slicer shape completion module normally recovers a latent code by test-time
+optimization (thousands of iterations). The `encoder/` package trains a
+feed-forward PointNet encoder that infers the latent from a partial point cloud
+in a single forward pass, giving near-identical reconstructions ~10,000x faster.
+
+The encoder is distilled from a trained model, so you build one directly from an
+existing `run_` folder (which holds `model_params_config.json`,
+`model/<epoch>.pth`, and `latent_codes/<epoch>.pth`):
+
+```bash
+conda activate NSM
+cd NSM/nsm
+
+# 1. Build the training set: for each latent code, marching-cubes the decoder
+#    into a surface and store the (surface_points -> latent) pair.
+python encoder/generate_latent_dataset.py \
+    --config run_v44/model_params_config.json \
+    --model run_v44/model/3000.pth \
+    --latent_codes run_v44/latent_codes/3000.pth \
+    --out encoder/data/latent_surface_dataset.pt
+
+# 2. Train the encoder (random cropping teaches partial -> full completion).
+python encoder/train_encoder.py \
+    --data encoder/data/latent_surface_dataset.pt \
+    --out encoder/checkpoints/encoder.pt
+
+# 3. (optional) Validate quality and speed vs. the optimizer.
+python encoder/evaluate_shape_completion.py \
+    --config run_v44/model_params_config.json \
+    --model run_v44/model/3000.pth \
+    --latent_codes run_v44/latent_codes/3000.pth \
+    --encoder encoder/checkpoints/encoder.pt
+```
+
+Point the Slicer module's "Fast Mode (Encoder)" option at the resulting
+`encoder/checkpoints/encoder.pt`. Retrain the encoder whenever the underlying
+model/latent codes change, since it is specific to that decoder.
+
 ## Model Loading
 
 NSM provides a convenient model loader that simplifies loading pre-trained Neural Shape Models. For **trained models**, you'll have:

--- a/encoder/evaluate_shape_completion.py
+++ b/encoder/evaluate_shape_completion.py
@@ -1,0 +1,229 @@
+"""Shape-completion eval: one-shot encoder vs. full 2-phase optimizer, scored by
+chamfer-to-GT and time. Outputs PNGs, .vtk meshes, results.csv, summary.md."""
+
+import os
+import sys
+import csv
+import time
+import argparse
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from NSM.helper_funcs import load_config, load_model_and_latents
+from NSM.mesh import create_mesh
+from NSM.datasets import SDFSamples
+from NSM.optimization import get_top_k_pcs, optimize_latent_partial
+from encoder.pointnet_encoder import PointNetEncoder
+
+
+def chamfer(a, b, n=3000):
+    a = torch.from_numpy(a[np.random.choice(len(a), min(n, len(a)), replace=False)])
+    b = torch.from_numpy(b[np.random.choice(len(b), min(n, len(b)), replace=False)])
+    d = torch.cdist(a, b)
+    return (d.min(1).values.mean() + d.min(0).values.mean()).item() / 2
+
+
+def recon_surface(model, z, res, device):
+    m = create_mesh(decoder=model, latent_vector=z, n_pts_per_axis=res,
+                    scale_to_original_mesh=False, device=device, verbose=False)
+    if m is None:
+        return None, None
+    return np.asarray(m.point_coords, dtype=np.float32), m
+
+
+def encode(enc, n_points, points, sdf, device, surf_thresh=0.01):
+    """Encoder fast-mode latent: near-surface points -> one forward pass."""
+    abs_sdf = sdf.abs().squeeze()
+    surf = points[abs_sdf < surf_thresh]
+    if surf.shape[0] < 32:
+        k = min(n_points, points.shape[0])
+        surf = points[torch.topk(abs_sdf, k, largest=False).indices]
+    sel = np.random.choice(surf.shape[0], n_points, replace=surf.shape[0] < n_points)
+    with torch.no_grad():
+        return enc(surf[sel].unsqueeze(0).to(device))
+
+
+def crop_partial(points, sdf, keep=0.65, rng=None):
+    """Drop the samples on one side of a random plane -> a partial 'broken' shape."""
+    rng = rng or np.random
+    surf_mask = sdf.abs().squeeze().cpu().numpy() < 0.01
+    center = points[surf_mask].mean(0) if surf_mask.any() else points.mean(0)
+    normal = torch.tensor(rng.randn(3), dtype=torch.float32)
+    normal = normal / normal.norm()
+    proj = (points.cpu() - center.cpu()) @ normal
+    thresh = torch.quantile(proj, 1.0 - keep)
+    mask = proj > thresh
+    return points[mask], sdf[mask]
+
+
+def render(out_png, gt_path, part_pts, enc_path, opt_path):
+    """2x2 panel: GT / partial input points / encoder & optimizer completions."""
+    import pyvista as pv
+    pv.OFF_SCREEN = True
+    pl = pv.Plotter(off_screen=True, shape=(2, 2), window_size=(900, 900))
+    panels = [("Ground truth", gt_path, "lightgray"),
+              ("Partial input", part_pts, "red"),
+              ("Encoder (fast)", enc_path, "deepskyblue"),
+              ("Optimizer (full)", opt_path, "limegreen")]
+    for idx, (title, obj, color) in enumerate(panels):
+        pl.subplot(idx // 2, idx % 2)
+        pl.add_text(title, font_size=10)
+        if isinstance(obj, str):
+            if obj and os.path.exists(obj):
+                pl.add_mesh(pv.read(obj), color=color, smooth_shading=True)
+        elif obj is not None and len(obj):
+            pl.add_points(pv.PolyData(np.asarray(obj, dtype=np.float32)),
+                          color=color, point_size=3, render_points_as_spheres=True)
+    pl.link_views()
+    pl.camera_position = "xy"
+    pl.screenshot(out_png)
+    pl.close()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default="run_v44/model_params_config.json")
+    ap.add_argument("--model", default="run_v44/model/3000.pth")
+    ap.add_argument("--latent_codes", default="run_v44/latent_codes/3000.pth")
+    ap.add_argument("--encoder", default="encoder/checkpoints/encoder.pt")
+    ap.add_argument("--out_dir", default="encoder/data/shape_completion_eval")
+    ap.add_argument("--n_shapes", type=int, default=5)
+    ap.add_argument("--keep", type=float, default=0.65, help="Fraction of samples kept when cropping.")
+    ap.add_argument("--n_samples", type=int, default=240, help="Optimizer point budget (production default).")
+    ap.add_argument("--phase1_iters", type=int, default=3000)
+    ap.add_argument("--phase2_iters", type=int, default=8000)
+    ap.add_argument("--res", type=int, default=128, help="Marching-cubes resolution (GT + reconstructions).")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--device", default="cuda")
+    args = ap.parse_args()
+
+    rng = np.random.RandomState(args.seed)
+    torch.manual_seed(args.seed)
+    device = args.device if torch.cuda.is_available() else "cpu"
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    config = load_config(args.config)
+    model, _, latent_codes = load_model_and_latents(args.model, args.latent_codes, config, device)
+    model.eval()
+    mean_latent = latent_codes.mean(dim=0, keepdim=True)
+    latent_std = latent_codes.std().mean()
+    _, top_k_reg = get_top_k_pcs(latent_codes, threshold=0.99)
+
+    ckpt = torch.load(args.encoder, map_location=device)
+    enc = PointNetEncoder(latent_size=ckpt["latent_size"]).to(device)
+    enc.load_state_dict(ckpt["model"]); enc.eval()
+    n_points = ckpt["n_points"]
+
+    sel = rng.choice(latent_codes.shape[0], args.n_shapes, replace=False)
+    rows = []
+    for i in sel:
+        z_true = latent_codes[int(i):int(i) + 1].to(device)
+        gt_pts, gt_mesh = recon_surface(model, z_true, args.res, device)
+        if gt_pts is None:
+            print(f"[{int(i)}] skipped (no GT surface)")
+            continue
+        gt_path = os.path.join(args.out_dir, f"shape_{int(i)}_gt.vtk")
+        gt_mesh.save_mesh(gt_path)
+
+        # production SDF sampling on the full GT mesh, then crop to a partial input
+        ds = SDFSamples(
+            list_mesh_paths=[gt_path], multiprocessing=False,
+            subsample=config["samples_per_object_per_batch"], print_filename=False,
+            n_pts=config["n_pts_per_object"], p_near_surface=config["percent_near_surface"],
+            p_further_from_surface=config["percent_further_from_surface"],
+            sigma_near=config["sigma_near"], sigma_far=config["sigma_far"],
+            rand_function=config["random_function"], center_pts=config["center_pts"],
+            norm_pts=config["normalize_pts"], scale_method=config["scale_method"],
+            reference_mesh=None, verbose=False, save_cache=config["cache"],
+            equal_pos_neg=config["equal_pos_neg"], fix_mesh=config["fix_mesh"])
+        sample, _ = ds[0]
+        pts_full = sample["xyz"].to(device).squeeze()
+        sdf_full = sample["gt_sdf"].to(device).reshape(-1, 1)
+        part_pts, part_sdf = crop_partial(pts_full, sdf_full, keep=args.keep, rng=rng)
+
+        # encoder: one forward pass
+        t = time.time()
+        z_enc = encode(enc, n_points, part_pts, part_sdf, device)
+        t_enc = time.time() - t
+        enc_pts, enc_mesh = recon_surface(model, z_enc, args.res, device)
+
+        # optimizer: full 2-phase production pipeline on a small point budget
+        idx = torch.randperm(part_pts.shape[0])[:args.n_samples]
+        opt_pts_in, opt_sdf_in = part_pts[idx], part_sdf[idx]
+        t = time.time()
+        z_opt, _ = optimize_latent_partial(
+            model, opt_pts_in, opt_sdf_in, config["latent_size"], mean_latent=mean_latent,
+            latent_init=latent_codes, top_k=top_k_reg, iters=args.phase1_iters, lr=1e-4,
+            lambda_reg=1e-3, clamp_val=1.0, latent_std=latent_std, scheduler_step=800,
+            scheduler_gamma=0.9, batch_inference_size=32768, multi_stage=False,
+            verbose=False, device=device)
+        z_opt, _ = optimize_latent_partial(
+            model, opt_pts_in, opt_sdf_in, config["latent_size"], latent_init=z_opt,
+            top_k=top_k_reg, iters=args.phase2_iters, lr=1e-5, lambda_reg=1e-5,
+            clamp_val=None, latent_std=latent_std, scheduler_step=800, scheduler_gamma=0.7,
+            batch_inference_size=32768, multi_stage=True, verbose=False, device=device)
+        t_opt = time.time() - t
+        opt_pts, opt_mesh = recon_surface(model, z_opt, args.res, device)
+
+        c_enc = chamfer(gt_pts, enc_pts) if enc_pts is not None else float("nan")
+        c_opt = chamfer(gt_pts, opt_pts) if opt_pts is not None else float("nan")
+        enc_path = os.path.join(args.out_dir, f"shape_{int(i)}_encoder.vtk")
+        opt_path = os.path.join(args.out_dir, f"shape_{int(i)}_optimizer.vtk")
+        if enc_mesh is not None:
+            enc_mesh.save_mesh(enc_path)
+        if opt_mesh is not None:
+            opt_mesh.save_mesh(opt_path)
+        try:
+            surf_part = part_pts[part_sdf.abs().squeeze() < 0.01].cpu().numpy()
+            render(os.path.join(args.out_dir, f"shape_{int(i)}_compare.png"),
+                   gt_path, surf_part, enc_path, opt_path)
+        except Exception as e:
+            print(f"  render failed for {int(i)}: {e}")
+
+        rows.append(dict(shape=int(i), enc_chamfer=c_enc, opt_chamfer=c_opt,
+                         enc_time=t_enc, opt_time=t_opt, speedup=t_opt / max(t_enc, 1e-6)))
+        print(f"[{int(i)}] enc_cham {c_enc:.4f} ({t_enc:.3f}s)  "
+              f"opt_cham {c_opt:.4f} ({t_opt:.1f}s)  {t_opt / max(t_enc, 1e-6):.0f}x")
+
+    if not rows:
+        print("No shapes evaluated.")
+        return
+
+    csv_path = os.path.join(args.out_dir, "results.csv")
+    with open(csv_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader(); w.writerows(rows)
+
+    mean = lambda k: float(np.nanmean([r[k] for r in rows]))
+    md = [
+        "# Shape completion: encoder (fast mode) vs. full optimizer",
+        "",
+        f"Model `{args.model}`, encoder `{args.encoder}`, {len(rows)} held-out shapes, "
+        f"partial input keeps {args.keep:.0%} of samples, reconstruction res {args.res}.",
+        "",
+        "| Method | Chamfer to GT (mean) | Time/shape (mean) |",
+        "|---|---|---|",
+        f"| Encoder (fast) | {mean('enc_chamfer'):.4f} | {mean('enc_time'):.3f} s |",
+        f"| Optimizer (phase1 {args.phase1_iters} + phase2 {args.phase2_iters}) | "
+        f"{mean('opt_chamfer'):.4f} | {mean('opt_time'):.1f} s |",
+        "",
+        f"**Mean speedup: {mean('speedup'):.0f}x faster** "
+        f"(lower chamfer = closer to ground truth).",
+        "",
+        "Per-shape comparison images: `shape_<id>_compare.png`. "
+        "Meshes (`_gt/_encoder/_optimizer.vtk`) open directly in Slicer.",
+    ]
+    with open(os.path.join(args.out_dir, "summary.md"), "w") as f:
+        f.write("\n".join(md) + "\n")
+    print("-" * 60)
+    print(f"encoder mean chamfer {mean('enc_chamfer'):.4f} | "
+          f"optimizer mean chamfer {mean('opt_chamfer'):.4f} | "
+          f"{mean('speedup'):.0f}x faster")
+    print(f"wrote {csv_path} and summary.md to {args.out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/encoder/generate_latent_dataset.py
+++ b/encoder/generate_latent_dataset.py
@@ -1,0 +1,131 @@
+"""Build the encoder-training set (surface points -> latent) from a trained decoder."""
+
+import os
+import sys
+import time
+import argparse
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from NSM.helper_funcs import load_config, load_model_and_latents
+from NSM.mesh import create_mesh
+
+
+def surface_points_from_latent(model, latent, n_pts_per_axis, device):
+    """Marching-cubes the decoder at `latent` and return surface vertices (N,3)."""
+    with torch.no_grad():
+        mesh = create_mesh(
+            decoder=model,
+            latent_vector=latent,
+            n_pts_per_axis=n_pts_per_axis,
+            scale_to_original_mesh=False,
+            device=device,
+            verbose=False,
+        )
+    if mesh is None:
+        return None
+    pts = np.asarray(mesh.point_coords, dtype=np.float32)
+    if pts.ndim != 2 or pts.shape[0] < 32:
+        return None
+    return pts
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default="run_v44/model_params_config.json")
+    ap.add_argument("--model", default="run_v44/model/3000.pth")
+    ap.add_argument("--latent_codes", default="run_v44/latent_codes/3000.pth")
+    ap.add_argument("--out", default="encoder/data/latent_surface_dataset.pt")
+    ap.add_argument("--n_pts_per_axis", type=int, default=128,
+                    help="Marching cubes resolution.")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="Only process the first N latents.")
+    ap.add_argument("--checkpoint_every", type=int, default=25,
+                    help="Checkpoint to <out>.partial every N latents.")
+    ap.add_argument("--restart", action="store_true",
+                    help="Ignore existing <out>.partial and restart.")
+    ap.add_argument("--device", default="cuda")
+    args = ap.parse_args()
+
+    device = args.device if torch.cuda.is_available() else "cpu"
+    config = load_config(args.config)
+    model, _, latent_codes = load_model_and_latents(
+        args.model, args.latent_codes, config, device
+    )
+    model.eval()
+
+    n = latent_codes.shape[0]
+    if args.limit is not None:
+        n = min(n, args.limit)
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    partial_path = args.out + ".partial"
+
+    meta = {
+        "n_pts_per_axis": args.n_pts_per_axis,
+        "latent_size": int(latent_codes.shape[1]),
+        "source_latents": args.latent_codes,
+        "source_model": args.model,
+    }
+
+    # resume from a compatible partial checkpoint if present
+    points_list, kept_latents, kept_idx = [], [], []
+    start = 0
+    if os.path.exists(partial_path) and not args.restart:
+        ck = torch.load(partial_path, weights_only=False)
+        if ck["meta"]["n_pts_per_axis"] != args.n_pts_per_axis:
+            print(f"Ignoring {partial_path}: res {ck['meta']['n_pts_per_axis']} "
+                  f"!= requested {args.n_pts_per_axis}")
+        else:
+            points_list = [p.numpy() for p in ck["points"]]
+            kept_latents = [z.numpy() for z in ck["latents"]]
+            kept_idx = list(ck["meta"]["kept_idx"])
+            start = ck["meta"]["next_idx"]
+            print(f"Resuming from {partial_path}: {len(points_list)} shapes kept, "
+                  f"restarting at latent {start}")
+
+    print(f"Generating surfaces for latents [{start}, {n}) at "
+          f"res={args.n_pts_per_axis} on {device}")
+
+    def flush(next_idx, final=False):
+        payload = {
+            "latents": torch.from_numpy(np.stack(kept_latents)).float()
+                       if kept_latents else torch.empty(0, meta["latent_size"]),
+            "points": [torch.from_numpy(p).float() for p in points_list],
+            "meta": {**meta, "kept_idx": kept_idx, "next_idx": next_idx},
+        }
+        path = args.out if final else partial_path
+        tmp = path + ".tmp"
+        torch.save(payload, tmp)
+        os.replace(tmp, path)  # atomic write
+
+    t0 = time.time()
+    for i in range(start, n):
+        z = latent_codes[i : i + 1].to(device)
+        pts = surface_points_from_latent(model, z, args.n_pts_per_axis, device)
+        if pts is not None:
+            points_list.append(pts)
+            kept_latents.append(latent_codes[i].cpu().numpy())
+            kept_idx.append(i)
+        else:
+            print(f"  [{i}] skipped (no valid surface)")
+        done = i - start + 1
+        if done % args.checkpoint_every == 0 or i == n - 1:
+            rate = done / (time.time() - t0)
+            eta = (n - i - 1) / rate if rate > 0 else 0
+            print(f"  [{i+1}/{n}] kept={len(points_list)} "
+                  f"({rate:.2f} shape/s, eta {eta/60:.1f} min)")
+            flush(next_idx=i + 1)
+
+    flush(next_idx=n, final=True)
+    if os.path.exists(partial_path):
+        os.remove(partial_path)
+    print(f"Saved {len(points_list)} shapes -> {args.out} "
+          f"({time.time()-t0:.1f}s total)")
+
+
+if __name__ == "__main__":
+    main()

--- a/encoder/pointnet_encoder.py
+++ b/encoder/pointnet_encoder.py
@@ -1,0 +1,45 @@
+"""Permutation-invariant PointNet encoder: N x 3 surface points -> DeepSDF latent."""
+
+import torch
+import torch.nn as nn
+
+
+class SharedMLP(nn.Module):
+    """1x1 convolutions applied identically to every point."""
+
+    def __init__(self, dims):
+        super().__init__()
+        layers = []
+        for i in range(len(dims) - 1):
+            layers += [
+                nn.Conv1d(dims[i], dims[i + 1], 1),
+                nn.BatchNorm1d(dims[i + 1]),
+                nn.ReLU(inplace=True),
+            ]
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.net(x)
+
+
+class PointNetEncoder(nn.Module):
+    def __init__(self, latent_size=512, point_feat_dims=(3, 64, 128, 256, 512),
+                 head_dims=(512, 512, 512), dropout=0.1):
+        super().__init__()
+        self.point_mlp = SharedMLP(point_feat_dims)
+        global_dim = point_feat_dims[-1]
+
+        head = []
+        prev = global_dim
+        for h in head_dims:
+            head += [nn.Linear(prev, h), nn.ReLU(inplace=True), nn.Dropout(dropout)]
+            prev = h
+        head += [nn.Linear(prev, latent_size)]
+        self.head = nn.Sequential(*head)
+
+    def forward(self, pts):
+        """pts: (B, N, 3) -> (B, latent_size)."""
+        x = pts.transpose(1, 2)
+        x = self.point_mlp(x)
+        x = torch.max(x, dim=2).values   # symmetric pool over points
+        return self.head(x)

--- a/encoder/train_encoder.py
+++ b/encoder/train_encoder.py
@@ -1,0 +1,141 @@
+"""Train the encoder to predict DeepSDF latents from (randomly cropped) surface points."""
+
+import os
+import sys
+import time
+import argparse
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.utils.data import Dataset, DataLoader
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from encoder.pointnet_encoder import PointNetEncoder
+
+
+def random_crop(pts, min_keep=0.4, max_keep=0.85):
+    """Simulate a partial scan by slicing off a slab along a random direction."""
+    n = pts.shape[0]
+    d = torch.randn(3)
+    d = d / (d.norm() + 1e-8)
+    proj = pts @ d
+    keep_frac = float(np.random.uniform(min_keep, max_keep))
+    k = max(int(n * keep_frac), 32)
+    idx = torch.topk(proj, k, largest=bool(np.random.rand() < 0.5)).indices
+    return pts[idx]
+
+
+def resample(pts, n_points):
+    """Sample exactly n_points (with replacement if the cloud is smaller)."""
+    n = pts.shape[0]
+    replace = n < n_points
+    idx = np.random.choice(n, n_points, replace=replace)
+    return pts[idx]
+
+
+class SurfaceLatentDataset(Dataset):
+    def __init__(self, points, latents, n_points=2048, augment=True,
+                 p_crop=0.6, noise_std=0.005):
+        self.points = points
+        self.latents = latents
+        self.n_points = n_points
+        self.augment = augment
+        self.p_crop = p_crop
+        self.noise_std = noise_std
+
+    def __len__(self):
+        return len(self.points)
+
+    def __getitem__(self, i):
+        pts = self.points[i]
+        if self.augment and np.random.rand() < self.p_crop:
+            pts = random_crop(pts)
+        pts = resample(pts, self.n_points)
+        if self.augment and self.noise_std > 0:
+            pts = pts + torch.randn_like(pts) * self.noise_std
+        return pts, self.latents[i]
+
+
+def latent_loss(pred, target):
+    mse = F.mse_loss(pred, target)
+    cos = (1 - F.cosine_similarity(pred, target, dim=1)).mean()
+    return mse + 0.1 * cos, mse, cos
+
+
+def run_epoch(model, loader, device, optimizer=None):
+    train = optimizer is not None
+    model.train(train)
+    tot, tot_mse, tot_cos, nb = 0.0, 0.0, 0.0, 0
+    for pts, tgt in loader:
+        pts, tgt = pts.to(device), tgt.to(device)
+        with torch.set_grad_enabled(train):
+            pred = model(pts)
+            loss, mse, cos = latent_loss(pred, tgt)
+        if train:
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        tot += loss.item(); tot_mse += mse.item(); tot_cos += cos.item(); nb += 1
+    return tot / nb, tot_mse / nb, tot_cos / nb
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data", default="encoder/data/latent_surface_dataset.pt")
+    ap.add_argument("--out", default="encoder/checkpoints/encoder.pt")
+    ap.add_argument("--epochs", type=int, default=300)
+    ap.add_argument("--batch_size", type=int, default=32)
+    ap.add_argument("--n_points", type=int, default=2048)
+    ap.add_argument("--lr", type=float, default=1e-3)
+    ap.add_argument("--val_frac", type=float, default=0.1)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    device = args.device if torch.cuda.is_available() else "cpu"
+
+    payload = torch.load(args.data)
+    points, latents = payload["points"], payload["latents"]
+    latent_size = latents.shape[1]
+    n = len(points)
+    print(f"Loaded {n} shapes, latent_size={latent_size}")
+
+    perm = np.random.permutation(n)
+    n_val = max(1, int(n * args.val_frac))
+    val_idx, tr_idx = perm[:n_val], perm[n_val:]
+    tr = SurfaceLatentDataset([points[i] for i in tr_idx], latents[tr_idx],
+                              n_points=args.n_points, augment=True)
+    va = SurfaceLatentDataset([points[i] for i in val_idx], latents[val_idx],
+                              n_points=args.n_points, augment=False)
+    tr_loader = DataLoader(tr, batch_size=args.batch_size, shuffle=True, drop_last=False)
+    va_loader = DataLoader(va, batch_size=args.batch_size, shuffle=False)
+
+    model = PointNetEncoder(latent_size=latent_size).to(device)
+    opt = torch.optim.Adam(model.parameters(), lr=args.lr, weight_decay=1e-5)
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=args.epochs)
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    best = float("inf")
+    t0 = time.time()
+    for ep in range(args.epochs):
+        tl, tmse, tcos = run_epoch(model, tr_loader, device, opt)
+        vl, vmse, vcos = run_epoch(model, va_loader, device, None)
+        sched.step()
+        if vl < best:
+            best = vl
+            torch.save({"model": model.state_dict(),
+                        "latent_size": latent_size,
+                        "n_points": args.n_points}, args.out)
+        if ep % 10 == 0 or ep == args.epochs - 1:
+            print(f"ep {ep:3d} | train {tl:.4f} (mse {tmse:.4f} cos {tcos:.4f}) "
+                  f"| val {vl:.4f} (mse {vmse:.4f} cos {vcos:.4f}) | best {best:.4f} "
+                  f"| {time.time()-t0:.0f}s")
+    print(f"Done. Best val {best:.4f} -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/encoder/validate_speedup.py
+++ b/encoder/validate_speedup.py
@@ -1,0 +1,112 @@
+"""Head-to-head: one-shot encoder vs. test-time latent optimization (chamfer + time)."""
+
+import os
+import sys
+import time
+import argparse
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from NSM.helper_funcs import load_config, load_model_and_latents
+from NSM.mesh import create_mesh
+from NSM.optimization import optimize_latent_partial
+from encoder.pointnet_encoder import PointNetEncoder
+from encoder.train_encoder import random_crop, resample
+
+
+def surface(model, z, res, device):
+    with torch.no_grad():
+        m = create_mesh(decoder=model, latent_vector=z, n_pts_per_axis=res,
+                        scale_to_original_mesh=False, device=device, verbose=False)
+    return np.asarray(m.point_coords, dtype=np.float32) if m is not None else None
+
+
+def chamfer(a, b, n=2000):
+    a = torch.from_numpy(a[np.random.choice(len(a), min(n, len(a)), replace=False)])
+    b = torch.from_numpy(b[np.random.choice(len(b), min(n, len(b)), replace=False)])
+    d = torch.cdist(a, b)
+    return (d.min(1).values.mean() + d.min(0).values.mean()).item() / 2
+
+
+def sdf_for_points(pts):
+    """Surface points have SDF 0; that's the target the optimizer fits."""
+    return torch.zeros(pts.shape[0], 1)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data", default="encoder/data/subset.pt")
+    ap.add_argument("--encoder", default="encoder/checkpoints/subset_enc.pt")
+    ap.add_argument("--config", default="run_v44/model_params_config.json")
+    ap.add_argument("--model", default="run_v44/model/3000.pth")
+    ap.add_argument("--latent_codes", default="run_v44/latent_codes/3000.pth")
+    ap.add_argument("--n_shapes", type=int, default=5)
+    ap.add_argument("--opt_iters", type=int, default=3000,
+                    help="Optimizer iters to compare against (full pipeline uses 11000).")
+    ap.add_argument("--res", type=int, default=96)
+    ap.add_argument("--device", default="cuda")
+    args = ap.parse_args()
+
+    device = args.device if torch.cuda.is_available() else "cpu"
+    config = load_config(args.config)
+    model, _, latent_codes = load_model_and_latents(
+        args.model, args.latent_codes, config, device)
+    mean_latent = latent_codes.mean(dim=0, keepdim=True)
+    latent_std = latent_codes.std().mean()
+
+    payload = torch.load(args.data)
+    points, latents = payload["points"], payload["latents"]
+    ckpt = torch.load(args.encoder, map_location=device)
+    enc = PointNetEncoder(latent_size=ckpt["latent_size"]).to(device)
+    enc.load_state_dict(ckpt["model"]); enc.eval()
+    n_points = ckpt["n_points"]
+
+    idxs = np.random.choice(len(points), args.n_shapes, replace=False)
+    print(f"{'shape':>6} | {'enc_cham':>9} {'enc_t(s)':>8} | {'opt_cham':>9} {'opt_t(s)':>8}")
+    e_c, e_t, o_c, o_t = [], [], [], []
+    for si in idxs:
+        z_true = latents[si:si+1].to(device)
+        gt = surface(model, z_true, args.res, device)
+
+        partial = random_crop(points[si])            # partial/broken input
+        partial = resample(partial, n_points)
+
+        # encoder: one forward pass
+        t = time.time()
+        with torch.no_grad():
+            z_enc = enc(partial.unsqueeze(0).to(device))
+        te = time.time() - t
+        rec_e = surface(model, z_enc, args.res, device)
+        ce = chamfer(gt, rec_e) if rec_e is not None else float("nan")
+
+        # optimizer: shape-completion path
+        pts_dev = partial.to(device)
+        sdf = sdf_for_points(partial).to(device)
+        t = time.time()
+        z_opt, _ = optimize_latent_partial(
+            model, pts_dev, sdf, ckpt["latent_size"], mean_latent=mean_latent,
+            latent_init=latent_codes, top_k=200, iters=args.opt_iters, lr=1e-4,
+            lambda_reg=1e-3, clamp_val=1.0, latent_std=latent_std,
+            scheduler_step=800, scheduler_gamma=0.9, batch_inference_size=32768,
+            multi_stage=False, verbose=False, device=device)
+        to = time.time() - t
+        rec_o = surface(model, z_opt, args.res, device)
+        co = chamfer(gt, rec_o) if rec_o is not None else float("nan")
+
+        e_c.append(ce); e_t.append(te); o_c.append(co); o_t.append(to)
+        print(f"{si:>6} | {ce:>9.4f} {te:>8.3f} | {co:>9.4f} {to:>8.2f}")
+
+    print("-" * 52)
+    print(f"{'mean':>6} | {np.mean(e_c):>9.4f} {np.mean(e_t):>8.3f} | "
+          f"{np.mean(o_c):>9.4f} {np.mean(o_t):>8.2f}")
+    print(f"\nSpeedup (encoder vs {args.opt_iters}-iter opt): "
+          f"{np.mean(o_t)/max(np.mean(e_t),1e-6):.0f}x faster")
+    print(f"Note: production pipeline runs 11000 iters, so real speedup is "
+          f"~{11000/args.opt_iters * np.mean(o_t)/max(np.mean(e_t),1e-6):.0f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/shape_completion_slicer.py
+++ b/shape_completion_slicer.py
@@ -21,11 +21,41 @@ def pv_to_tiny3d(mesh_pv):
     mesh_o3d.compute_vertex_normals()
     return mesh_o3d
 
+def encoder_latent(encoder_ckpt, points_full, sdf_full, device, surf_thresh=0.01):
+    """Fast mode: predict the full-shape latent from partial near-surface points
+    in one forward pass."""
+    from encoder.pointnet_encoder import PointNetEncoder
+
+    if not os.path.isabs(encoder_ckpt):
+        encoder_ckpt = os.path.join(os.path.dirname(os.path.abspath(__file__)), encoder_ckpt)
+    ckpt = torch.load(encoder_ckpt, map_location=device)
+    enc = PointNetEncoder(latent_size=ckpt["latent_size"]).to(device)
+    enc.load_state_dict(ckpt["model"])
+    enc.eval()
+    n_points = ckpt["n_points"]
+
+    abs_sdf = sdf_full.abs().squeeze()
+    surf = points_full[abs_sdf < surf_thresh]
+    if surf.shape[0] < 32:
+        # Not enough near-surface samples: fall back to the k smallest |sdf|.
+        k = min(n_points, points_full.shape[0])
+        idx = torch.topk(abs_sdf, k, largest=False).indices
+        surf = points_full[idx]
+
+    n = surf.shape[0]
+    sel = np.random.choice(n, n_points, replace=n < n_points)
+    surf = surf[sel]
+    with torch.no_grad():
+        z = enc(surf.unsqueeze(0).to(device))
+    return z
+
+
 def main(config_path=None, model_path=None, latent_codes_path=None, input_mesh_path=None, output_folder_path=None,
          estimate_uncertainty=False, propagation_mode='analytical', data_std=2e-5, latent_prior_std=5e-4,
          data_weight=1.0, latent_weight=1.0, mc_samples=2000, n_triangles=5000,
          n_samples=240, phase1_iters=3000, phase1_lr=1e-4, phase1_lambda_reg=1e-3,
-         phase2_iters=8000, phase2_lr=1e-5, phase2_lambda_reg=1e-5, n_pts_per_axis=256):
+         phase2_iters=8000, phase2_lr=1e-5, phase2_lambda_reg=1e-5, n_pts_per_axis=256,
+         fast_mode=False, encoder_ckpt=None, refine_iters=0):
     USE_TINY3D = True  # Set this flag based on Slicer environment
 
     # Dynamically import open3d/tiny3d depending on USE_TINY3D
@@ -134,28 +164,37 @@ def main(config_path=None, model_path=None, latent_codes_path=None, input_mesh_p
         print("\n-----Setting up dataset-----\n")
         sdf_sample = sdf_dataset[0]  # returns a dict
         sample_dict, _ = sdf_sample
-        points = sample_dict['xyz'].to(device) # shape: [N, 3]
-        sdf_vals = sample_dict['gt_sdf'].to(device)  # shape: [N, 1]
+        points_full = sample_dict['xyz'].to(device).squeeze()      # shape: [N, 3]
+        sdf_full = sample_dict['gt_sdf'].to(device).reshape(-1, 1)  # shape: [N, 1]
 
-        # Use a subset of the points for optizimation/reconstruction
-        indices = torch.randperm(points.size(0))[:n_samples] # Generate n_samples random indices
-        # Downsample the points and SDF values
-        points = points[indices]
-        points = points.squeeze()
-        sdf_vals = sdf_vals[indices]
-        sdf_vals = sdf_vals.reshape(-1, 1)
+        # Use a subset of the points for optimization/refinement
+        indices = torch.randperm(points_full.size(0))[:n_samples] # Generate n_samples random indices
+        points = points_full[indices].squeeze()
+        sdf_vals = sdf_full[indices].reshape(-1, 1)
 
-        # Optimize latents
-        print("\n-----Optimizing latents----\n")
-        # Phase 1 - Coarse Optimization - get a global shape in the right area of latent space (close to target specimen (far enough from mean); but not so far from mean that it is noisy or unrealistic)
-        latent_partial, _ = optimize_latent_partial(model, points.squeeze(), sdf_vals, config['latent_size'], mean_latent=mean_latent, latent_init=latent_codes, top_k=top_k_reg, 
-                                                         iters=phase1_iters, lr=phase1_lr, lambda_reg=phase1_lambda_reg, clamp_val=1.0, latent_std=latent_std, scheduler_step=800, scheduler_gamma=0.9, 
-                                                         batch_inference_size=32768, multi_stage=False, device=device)
-        # Phase 2 - Refinement - emphasis on local SDF samples and surface consistency to refine target specimen shape
-        latent_partial, _ = optimize_latent_partial(model, points.squeeze(), sdf_vals, config['latent_size'], latent_init=latent_partial, top_k=top_k_reg, 
-                                                             iters=phase2_iters, lr=phase2_lr, lambda_reg=phase2_lambda_reg, clamp_val=None, latent_std=latent_std, scheduler_step=800, scheduler_gamma=0.7, 
-                                                             batch_inference_size=32768, multi_stage=True, device=device) # True because second stage using already initialized latent
-        print("\nTranslated novel mesh into latent space!\n")
+        if fast_mode:
+            # ---- Fast mode: one-shot encoder instead of full latent optimization ----
+            print("\n-----Fast mode: encoding latent (single forward pass)----\n")
+            latent_partial = encoder_latent(encoder_ckpt, points_full, sdf_full, device)
+            if refine_iters > 0:
+                # MetaSDF-style: encoder output as a learned init + a few refine steps.
+                print(f"Refining encoder latent for {refine_iters} iters...")
+                latent_partial, _ = optimize_latent_partial(model, points.squeeze(), sdf_vals, config['latent_size'], latent_init=latent_partial, top_k=top_k_reg,
+                                                             iters=refine_iters, lr=phase2_lr, lambda_reg=phase2_lambda_reg, clamp_val=None, latent_std=latent_std, scheduler_step=800, scheduler_gamma=0.7,
+                                                             batch_inference_size=32768, multi_stage=True, device=device)
+            print("\nEncoded novel mesh into latent space!\n")
+        else:
+            # Optimize latents
+            print("\n-----Optimizing latents----\n")
+            # Phase 1 - Coarse Optimization - get a global shape in the right area of latent space (close to target specimen (far enough from mean); but not so far from mean that it is noisy or unrealistic)
+            latent_partial, _ = optimize_latent_partial(model, points.squeeze(), sdf_vals, config['latent_size'], mean_latent=mean_latent, latent_init=latent_codes, top_k=top_k_reg,
+                                                             iters=phase1_iters, lr=phase1_lr, lambda_reg=phase1_lambda_reg, clamp_val=1.0, latent_std=latent_std, scheduler_step=800, scheduler_gamma=0.9,
+                                                             batch_inference_size=32768, multi_stage=False, device=device)
+            # Phase 2 - Refinement - emphasis on local SDF samples and surface consistency to refine target specimen shape
+            latent_partial, _ = optimize_latent_partial(model, points.squeeze(), sdf_vals, config['latent_size'], latent_init=latent_partial, top_k=top_k_reg,
+                                                                 iters=phase2_iters, lr=phase2_lr, lambda_reg=phase2_lambda_reg, clamp_val=None, latent_std=latent_std, scheduler_step=800, scheduler_gamma=0.7,
+                                                                 batch_inference_size=32768, multi_stage=True, device=device) # True because second stage using already initialized latent
+            print("\nTranslated novel mesh into latent space!\n")
         
         # Reconstruction parameters
         recon_grid_origin = 1.0
@@ -260,7 +299,10 @@ def main(config_path=None, model_path=None, latent_codes_path=None, input_mesh_p
 
 if __name__ == "__main__":
 
-    modulePath = os.path.join(os.path.dirname((__file__)), 'NSM')
+    repoRoot = os.path.dirname(os.path.abspath(__file__))
+    if repoRoot not in sys.path:
+        sys.path.insert(0, repoRoot)  # so `import encoder...` (fast mode) resolves
+    modulePath = os.path.join(repoRoot, 'NSM')
     print("Module path: ", modulePath)
     if modulePath not in sys.path:
         sys.path.insert(0, modulePath)
@@ -289,6 +331,12 @@ if __name__ == "__main__":
     parser.add_argument('--phase2_lr', type=float, default=1e-5)
     parser.add_argument('--phase2_lambda_reg', type=float, default=1e-5)
     parser.add_argument('--n_pts_per_axis', type=int, default=256)
+    # Fast mode (one-shot encoder)
+    parser.add_argument('--fast_mode', action='store_true')
+    parser.add_argument('--encoder_ckpt', type=str,
+                        default=os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                             'encoder', 'checkpoints', 'encoder.pt'))
+    parser.add_argument('--refine_iters', type=int, default=0)
 
     # Check if we are using positional args or argparse format
     if len(sys.argv) == 6 and not sys.argv[1].startswith('-'):
@@ -323,5 +371,8 @@ if __name__ == "__main__":
             phase2_iters=args.phase2_iters,
             phase2_lr=args.phase2_lr,
             phase2_lambda_reg=args.phase2_lambda_reg,
-            n_pts_per_axis=args.n_pts_per_axis
+            n_pts_per_axis=args.n_pts_per_axis,
+            fast_mode=args.fast_mode,
+            encoder_ckpt=args.encoder_ckpt,
+            refine_iters=args.refine_iters
         )


### PR DESCRIPTION
PointNet-style encoder that takes partial surface points and directly predicts the DeepSDF latent code.

You can download a trained encoder on the run_v44 model here (I was not able to upload it to the haag dropbox directly):
https://www.dropbox.com/scl/fi/az7lbqmk2e5l7flzmnyva/encoder.pt?rlkey=vlpp8eylvpgeh0jpmk7rw8ilh&st=nukwvv4h&dl=0

Additionally I've extended the readme to exaplain how to train your own encoder based on a model.

Results on a 5 shape sample:
| Shape | Encoder chamfer | Optimizer chamfer | Encoder time | Optimizer time | Speedup |
|------:|----------------:|------------------:|-------------:|---------------:|--------:|
| 279  | 0.0048 | 0.0051 | 0.014 s | 437 s | 31,403× |
| 385  | 0.0044 | 0.0067 | 0.001 s | 525 s | 365,408× |
| 399  | 0.0046 | 0.0060 | 0.001 s | 675 s | 493,617× |
| 983  | 0.0037 | 0.0039 | 0.001 s | 564 s | 379,162× |
| 1843 | 0.0053 | 0.0044 | 0.001 s | 443 s | 300,493× |
| **mean** | **0.0046** | **0.0052** | **0.004 s** | **529 s** | **~314,000×** |

Details:
- Dataset = 1959 shapes; encoder trained on 1764, held out 195.
- All 5 eval shapes are part of the 195 held-out set.
- Quality is on par or better. Mean chamfer-to-GT is lower for the encoder (0.0046 vs 0.0052). It won 4 of 5 shapes; the optimizer only edged it on shape 1843. Lower = closer to ground truth.
- Speed is not close. The encoder produces a latent in ~1 ms vs ~9 min for the full 2-phase optimizer (3000 + 8000 iters), roughly a 300,000× speedup, and that's the fair comparison since both methods reconstruct at the same res 128.

**Shape 279:**
<img width="900" height="900" alt="shape_279_compare" src="https://github.com/user-attachments/assets/89c863bd-5713-481f-9bb2-ca6b9b942a2f" />

**Shape 385:**
<img width="900" height="900" alt="shape_385_compare" src="https://github.com/user-attachments/assets/19688fbe-4869-4066-bc8a-681837f5f314" />

**Shape 399:**
<img width="900" height="900" alt="shape_399_compare" src="https://github.com/user-attachments/assets/3854ba50-438d-40c1-b6d0-d5ced2465282" />

**Shape 983:**
<img width="900" height="900" alt="shape_983_compare" src="https://github.com/user-attachments/assets/320be89a-8f63-4cb7-8d9c-6da8b381bbdb" />

**Shape 1843:**
<img width="900" height="900" alt="shape_1843_compare" src="https://github.com/user-attachments/assets/515d7df3-6de9-4fc7-83db-58925f193df5" />
